### PR TITLE
use `usize` to store index and use functional programming style to simplify code

### DIFF
--- a/crates/allay-compiler/src/ast.rs
+++ b/crates/allay-compiler/src/ast.rs
@@ -162,7 +162,7 @@ pub enum TopLevel {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GetField {
-    Index(i32),
+    Index(usize),
     Name(String),
 }
 

--- a/crates/allay-compiler/src/error.rs
+++ b/crates/allay-compiler/src/error.rs
@@ -37,7 +37,7 @@ pub enum InterpretError {
 
     /// Index out of bounds when accessing a list
     #[error("Index out of bounds: {0}")]
-    IndexOutOfBounds(i32),
+    IndexOutOfBounds(usize),
 }
 
 /// The result type for interpreter.

--- a/crates/allay-compiler/src/parser.rs
+++ b/crates/allay-compiler/src/parser.rs
@@ -546,7 +546,7 @@ impl ASTBuilder for GetField {
             Rule::number => {
                 let idx = inner
                     .as_str()
-                    .parse::<i32>()
+                    .parse::<usize>()
                     .map_err(|e| ParseError::InvalidNumber(inner.as_str().to_string(), e))?;
                 Ok(GetField::Index(idx))
             }


### PR DESCRIPTION
- use `usize` to store index (match convention of Rust)
- use functional programming style to simplify code